### PR TITLE
feat(etl): filter hints to improve game experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is a spanish version of [Semantle](https://semantle.novalis.org).
 ## Running locally
 ### One-time setup
 1. Get spanish Word2vec dataset from [Spanish Billion Word Corpus and Embeddings](https://crscardellino.github.io/SBWCE/). Download the word2vec binary format to the `data` directory. _Unzip it_
+1. Download the "Lista total de frecuencias" data file (`CREA_total.ZIP`) from [Corpus de Referencia del Español Actual (CREA) - Listado de frecuencias](http://corpus.rae.es/lfrecuencias.html) to the `data` directory. _Do not unzip it_
 1. Create a python virtual environment: `python3 -m venv .`
 1. Activate the environment: `source bin/activate`
 1. Install all dependencies: `python3 -m pip install -r requirements.txt`
@@ -31,4 +32,7 @@ Original Semantle code by [David Turner](https://novalis.org). Changes:
 
 Word2vec data set by Cristian Cardellino. Citation:
 > Cristian Cardellino: Spanish Billion Words Corpus and Embeddings (March 2016), https://crscardellino.github.io/SBWCE/
+
+Frequent words data set from [Corpus de referencia del español actual](http://corpus.rae.es/lfrecuencias.html). Citation:
+> REAL ACADEMIA ESPAÑOLA: Banco de datos (CREA) [en línea]. Corpus de referencia del español actual. <http://www.rae.es> [2022-02-25]
 

--- a/dump-hints.py
+++ b/dump-hints.py
@@ -1,58 +1,76 @@
-import gensim.models.keyedvectors as word2vec
-
-import heapq
-
-from tqdm import tqdm
+import io
+import pickle
 import re
 import time
+from zipfile import ZipFile
 
-import code, traceback, signal
+import gensim.models.keyedvectors as word2vec
+from tqdm import tqdm
 
+SIMPLE_WORD_REGEX = re.compile("^[a-z]*")
+DISALLOWED_ENDINGS = ['rlo', 'rlos', 'rla', 'rlas', 'rle', 'rles', 'ando', 'iendo', 'ía', 'ían', 'ías', 'ísima', 'ísimo', 'ará', 'aré' \
+        'arse', 'erse', 'irse', 'ió', 'ié', 'etí', 'ola', 'ole', 'ote', 'ose', 'ándolo', 'ándola', 'ándole']
+TOP_N = 1000
+"""
+Should we exclude this word from the common word list?
+"""
+def is_disallowed_word(word):
+    return any(map(lambda ending: word.endswith(ending), DISALLOWED_ENDINGS)) or \
+            len(word) < 4
+
+"""
+Reads the common words list.
+We filter the hints by this list to reduce "noise"/improve gradient in the hints.
+"""
+def get_common_words_set():
+    result = set()
+    with ZipFile("data/CREA_total.ZIP", 'r') as crea_zip:
+        with crea_zip.open("CREA_total.TXT") as crea_txt:
+            # skip header
+            next(crea_txt)
+            for line in tqdm(io.TextIOWrapper(crea_txt, 'iso8859'), 'reading common words file'):
+                # cols: 0: word number, 1: word, 2: absolute freq, 3: normalized freq.
+                word = line.strip().split('\t')[1].strip()
+                if SIMPLE_WORD_REGEX.match(word) and not is_disallowed_word(word):
+                    result.add(word)
+    return result
+
+common_words_set = get_common_words_set()
 # Set to None to read all words in the model. Useful to set a low number to test script.
-word_limit = None
+WORD_LIMIT = None
 t_word2vec = time.process_time()
 print("loading word2vec file...")
-model = word2vec.KeyedVectors.load_word2vec_format("data/SBW-vectors-300-min5.bin", binary=True, limit=word_limit)
+model = word2vec.KeyedVectors.load_word2vec_format("data/SBW-vectors-300-min5.bin", binary=True, limit=WORD_LIMIT)
 print(f'done in {time.process_time() - t_word2vec} seconds')
 
-simple_word = re.compile("^[a-z]*")
-words = []
-for word in tqdm(iterable=model.vocab, desc='loading words from model'):
-#    if simple_word.match(word) and word in allowable_words:
-    words.append(word)
-
 hints = {}
-with open("static/assets/js/secretWords.js") as f:
-    for line in tqdm(iterable=f.readlines(), desc='generating hints (takes 1~2 minutes to start)'):
-        line = line.strip()
-        if not '"' in line:
+with open("static/assets/js/secretWords.js", encoding="utf-8") as secret_words:
+    for secret in tqdm(iterable=secret_words.readlines(), desc='generating hints (takes 1~2 minutes to start)'):
+        secret = secret.strip()
+        if not '"' in secret:
             continue
-        secret = line.strip('",')
+        secret = secret.strip('",')
         # secret might not be in the model vocabulary if we loaded a subset
         # of the model. Skip generating hints if that's the case
         if secret not in model.vocab:
             continue
         # Calculate nearest using KeyedVectors' `most_similar`.
-        # It calculates cosine similarity, which is _exactly_ what
-        # this module's `similarity` does.
+        # It calculates cosine similarity, which is  what
+        # the original Semantle does.
         # The first call to `most_similar` is s l o w: the progress
         # indicator will start moving after a minute or so.
         # This is _way_ faster than doing a nested "secret x vocab" loop.
-        nearest = []
-        # TODO: figure out a pythonic way to swap the tuples (map?)
-        for most_similar in model.most_similar(secret, topn=1000):
-            heapq.heappush(nearest, (most_similar[1], most_similar[0]))
-        # The old way has `nearest` include the similarity with itself.
-        # `most_similar` doesn't, so we need to add it manually.
-        if len(nearest) >= 1000:
-            heapq.heappushpop(nearest, (1, secret))
-        else:
-            heapq.heappush(nearest, (1, secret))
-
+        # Slice up to TOP_N -1 to leave room for the secret word.
+        most_similar = [it for it in model.most_similar(secret, topn=100 * TOP_N) if it[0] in common_words_set][0:TOP_N - 1]
+        # Nearest must include the secret. `most_similar` doesn't, so we need to add it manually.
+        most_similar.extend([(secret, 1)])
+        if len(most_similar) < TOP_N:
+            raise RuntimeError(f'most_similar has too few common words: {len(most_similar)} after filtering, needs {TOP_N}')
+        # store-hints.py expects a (score, word) tuple
+        nearest = [(item[1], item[0]) for item in most_similar]
+        # store-hints.py relies on nearest's order to get the closest, 10th and 1000th nearby element.
         nearest.sort()
         hints[secret] = nearest
 
-import pickle
-with open(b"nearest.pickle", "wb") as f:
-    pickle.dump(hints, f)
-
+with open(b"nearest.pickle", "wb") as pickled:
+    pickle.dump(hints, pickled)


### PR DESCRIPTION
`nearby` can have a lot of similar, non-frequent words. That reduces it
usefulness as a way to find a path towards the secret word.

This commit filters the most similar words as extracted from the
Word2vec model, with a set of common spanish words. It also removes some
"boring" words based on their endings (gerunds, etc.).

Performance suffers a bit, as we now have to oversample the most similar
words, to make sure there's 1k after applying filters. Currently the
oversample factor is 100x. It might be possible to dynamically adjust
it, but that's a story for another day.

There's also a bit of cleaning.