### PR TITLE
fix(app): cosine similarity folds negative similarity into positive

### DIFF
--- a/static/assets/js/semantle.js
+++ b/static/assets/js/semantle.js
@@ -43,7 +43,7 @@ function dot(f1, f2) {
 }
 
 function getCosSim(f1, f2) {
-    return Math.abs(dot(f1,f2)/(mag(f1)*mag(f2)));
+    return dot(f1,f2)/(mag(f1)*mag(f2));
 }
 
 


### PR DESCRIPTION
Currently the app takes the absolute value of the actual cosine
similarity.

This affects game experience by merging results that are opposites
(negative similarity) into positive ones, misleading players into a path
that doe not lead to the secret word.

wiki: https://en.wikipedia.org/wiki/Cosine_similarity#Definition

upstream: https://gitlab.com/novalis_dt/semantle/-/commit/d788065