### PR TITLE
fix(app): update cursor style for interactive elements

### DIFF
--- a/static/assets/styles.css
+++ b/static/assets/styles.css
@@ -2,6 +2,10 @@ th {
     padding-right: 3em;
 }
 
+th#chronoOrder, th#alphaOrder, th#similarityOrder, input#give-up-btn, input#guess-btn, input#lower{
+    cursor: pointer;
+}
+
 .gaveup {
     border: 1px solid black;
     padding-top: 0.7ex;


### PR DESCRIPTION
Cursor should be a pointer for interactive elements.
This is happening for links currently but not for buttons,
checkboxes, or sort headers

upstream: https://gitlab.com/novalis_dt/semantle/-/commit/be9bf0e3b9ac152cb05b0b0997c091dbe54bd572