### PR TITLE
chore: improve repo and deployment utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-word2vec.db
+word2vec*.db
 nearest.pickle
 static/assets/js/british_spellings.js
 bin/
@@ -7,3 +7,4 @@ lib/
 pyvenv.cfg
 __pycache__
 logs/*
+*.bak

--- a/.rsync-filter
+++ b/.rsync-filter
@@ -1,0 +1,12 @@
+- .git/
+- .gitignore
+- *.bak
+- *.swp
+- *.tmp
+- nearest.pickle
+- bin/
+- lib/
+- data/
+- pyvenv.cfg
+- __pycache__
+- logs/


### PR DESCRIPTION
This commit improves `.gitignore` to better cover different versions of
the word2vec database file. You really don't want to commit that.

It also adds an `.rsync-filter` file that can be used for `rsync`
deployments. It excludes files and directories that should not be pushed
to prod hosts.